### PR TITLE
rarfile: tests: Provide path to test scripts

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,6 @@
 test:
-	./test.sh
+	./test1.sh
+	./test2.sh
 
 clean:
 	rm -rf __pycache__


### PR DESCRIPTION
- test/Makefile: Provide correct path to test scripts.

Currently, 'test/Makefile' tries to run './test.sh' when you invoke `make test`. This file doesn't exist.

This patch updates the Makefile with the correct path of the two test scripts.
